### PR TITLE
feat: Add slideover modal support and enhance draggable functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-**Important:** When slideoverDraggable is disabled (default), slideouts will maintain their original Filament appearance and behavior without any modifications.
+**Important:** When `slideoverDraggable` is disabled (the default), slideover modals/slideouts use the standard Filament implementation: no additional CSS classes or JavaScript behavior from this plugin are applied.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ public function panel(Panel $panel): Panel
         // ... other configuration
         ->plugin(
             DraggableModalPlugin::make()
-                ->slideoverDraggable(false) 
+                ->slideoverDraggable(true) 
         );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A simple yet powerful Filament v5 plugin to make all your modals draggable. Impr
 - **Filament v5 Ready**: Designed specifically for the latest Filament version.
 - **Smooth Dragging**: Uses fixed positioning and handles CSS transforms to prevent jumping.
 - **Smart Handle Detection**: Draggable by the modal header, but buttons and inputs remain clickable.
+- **Slideover Support**: Optional draggable functionality for slideover modals (disabled by default).
 
 ## Installation
 
@@ -36,6 +37,28 @@ public function panel(Panel $panel): Panel
         ->plugin(DraggableModalPlugin::make());
 }
 ```
+
+That's it! All your regular modals are now draggable.
+
+### Slideover Modals
+
+By default, **slideover modals are NOT draggable** to preserve their native behavior. If you want to make slideover modals draggable as well, you can enable this feature:
+
+```php
+use Sanzgrapher\DraggableModal\DraggableModalPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ... other configuration
+        ->plugin(
+            DraggableModalPlugin::make()
+                ->slideoverDraggable(false) 
+        );
+}
+```
+
+**Important:** When slideoverDraggable is disabled (default), slideouts will maintain their original Filament appearance and behavior without any modifications.
 
 ## Troubleshooting
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/sanzgrapher/filament-draggable-modal",
   "require": {
     "php": "^8.2",
-    "filament/filament": "^4.0"
+    "filament/filament": "^4.0|^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/resources/dist/drag-modal.css
+++ b/resources/dist/drag-modal.css
@@ -12,7 +12,7 @@
 .fi-modal-window.fi-modal-draggable-enabled {
     display: flex;
     flex-direction: column;
-    max-height: 90vh;
+    /* max-height: 90vh; */
     overflow: hidden;
 }
 
@@ -29,7 +29,7 @@
 .fi-modal-window.fi-modal-draggable-enabled .fi-modal-header,
 .fi-modal-window.fi-modal-draggable-enabled footer,
 .fi-modal-window.fi-modal-draggable-enabled .fi-modal-footer {
-    flex-shrink: 0;
+    flex-shrink: 0;  
 }
 
 

--- a/resources/dist/drag-modal.css
+++ b/resources/dist/drag-modal.css
@@ -2,18 +2,75 @@
  * Filament v5 Draggable Modal Styles
  */
 
-.fi-modal-window {
-  transition: none !important;
+.fi-modal-window.hidden,
+.fi-modal-window[style*="display: none"],
+.fi-modal-window[style*="display:none"] {
+    display: none !important;
 }
 
-.fi-modal-header,
-.fi-modal-heading,
-[data-slot="title"] {
-  cursor: move !important;
+/* Ensure modal window is flexbox container with max height - only for draggable enabled */
+.fi-modal-window.fi-modal-draggable-enabled {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+    overflow: hidden;
 }
 
-.fi-modal-header button,
-.fi-modal-header a,
-.fi-modal-header input {
-  cursor: pointer !important;
+/* Content area needs to scroll - only for draggable modals */
+.fi-modal-window.fi-modal-draggable-enabled .fi-modal-content,
+.fi-modal-window.fi-modal-draggable-enabled [data-slot="content"] {
+    overflow-y: auto;
+    overflow-x: hidden;
+    flex: 1 1 auto;
+    min-height: 0; 
 }
+
+/* Prevent header/footer from shrinking - only for draggable modals */
+.fi-modal-window.fi-modal-draggable-enabled .fi-modal-header,
+.fi-modal-window.fi-modal-draggable-enabled footer,
+.fi-modal-window.fi-modal-draggable-enabled .fi-modal-footer {
+    flex-shrink: 0;
+}
+
+
+.fi-modal-window.fi-modal-draggable-enabled .fi-modal-header {
+    cursor: move;
+    user-select: none;
+}
+
+.fi-modal-window.fi-modal-draggable-enabled .fi-modal-header:active {
+    cursor: grabbing;
+}
+
+.fi-modal-window.is-dragging {
+    user-select: none;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+/* Scrollbar styles - only for draggable modals */
+.fi-modal-window.fi-modal-draggable-enabled [data-slot="content"]::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.fi-modal-window.fi-modal-draggable-enabled .fi-modal-content::-webkit-scrollbar-thumb,
+.fi-modal-window.fi-modal-draggable-enabled [data-slot="content"]::-webkit-scrollbar-thumb {
+    background: rgba(156, 163, 175, 0.5);
+    border-radius: 4px;
+}
+
+.fi-modal-window.fi-modal-draggable-enabled .fi-modal-content::-webkit-scrollbar-thumb:hover,
+.fi-modal-window.fi-modal-draggable-enabled [data-slot="content"]::-webkit-scrollbar-thumb:hover {
+    background: rgba(156, 163, 175, 0.7);
+}
+
+/* Dark mode scrollbar */
+.dark .fi-modal-window.fi-modal-draggable-enabled .fi-modal-content::-webkit-scrollbar-thumb,
+.dark .fi-modal-window.fi-modal-draggable-enabled [data-slot="content"]::-webkit-scrollbar-thumb {
+    background: rgba(75, 85, 99, 0.5);
+}
+
+.dark .fi-modal-window.fi-modal-draggable-enabled .fi-modal-content::-webkit-scrollbar-thumb:hover,
+.dark .fi-modal-window.fi-modal-draggable-enabled [data-slot="content"]::-webkit-scrollbar-thumb:hover {
+    background: rgba(75, 85, 99, 0.7);
+}
+

--- a/resources/dist/drag-modal.js
+++ b/resources/dist/drag-modal.js
@@ -7,29 +7,31 @@
  * - border constraints to prevent dragging completely off-screen.
  */
 (function () {
-    'use strict';
+    "use strict";
 
-    const MODAL_SELECTOR = '.fi-modal-window';
-    const SLIDEOVER_CLASS = 'fi-modal-slide-over';
+    const MODAL_SELECTOR = ".fi-modal-window";
+    const SLIDEOVER_CLASS = "fi-modal-slide-over";
 
     const HANDLE_SELECTORS = [
-        '.fi-modal-header',
-        '.fi-modal-heading',
+        ".fi-modal-header",
+        ".fi-modal-heading",
         '[data-slot="title"]',
-        'header',
+        "header",
     ];
 
     const attachedModals = new WeakSet();
 
     function getConfig() {
-        return window.FilamentDraggableModalConfig || {
-            enableSlideoverDraggable: false
-        };
+        return (
+            window.FilamentDraggableModalConfig || {
+                enableSlideoverDraggable: false,
+            }
+        );
     }
 
     function isSlideoverModal(modal) {
         if (!modal) return false;
-        const wrapper = modal.closest('.fi-modal');
+        const wrapper = modal.closest(".fi-modal");
         return wrapper && wrapper.classList.contains(SLIDEOVER_CLASS);
     }
 
@@ -38,12 +40,14 @@
         const rect = el.getBoundingClientRect();
         if (rect.width === 0 || rect.height === 0) return false;
         const style = window.getComputedStyle(el);
-        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (style.display === "none" || style.visibility === "hidden")
+            return false;
         if (parseFloat(style.opacity) < 0.1) return false;
-        const wrapper = el.closest('.fi-modal');
+        const wrapper = el.closest(".fi-modal");
         if (wrapper) {
             const ws = window.getComputedStyle(wrapper);
-            if (ws.display === 'none' || ws.visibility === 'hidden') return false;
+            if (ws.display === "none" || ws.visibility === "hidden")
+                return false;
             if (parseFloat(ws.opacity) < 0.1) return false;
         }
         return true;
@@ -60,7 +64,7 @@
 
         attachedModals.add(modal);
 
-        modal.classList.add('fi-modal-draggable-enabled');
+        modal.classList.add("fi-modal-draggable-enabled");
 
         let handle = null;
         for (const sel of HANDLE_SELECTORS) {
@@ -70,14 +74,23 @@
         if (!handle) handle = modal;
 
         // Set cursor and user-select styling explicitly
-        handle.style.userSelect = 'none';
-        handle.style.cursor = 'move';
+        handle.style.userSelect = "none";
+        handle.style.cursor = "move";
 
-        let startX, startY, initialX, initialY, isDragging = false;
+        let startX,
+            startY,
+            initialX,
+            initialY,
+            isDragging = false;
 
         function onMouseDown(e) {
             if (e.button !== 0) return;
-            if (e.target.closest('button, input, select, textarea, a, [role="button"]')) return;
+            if (
+                e.target.closest(
+                    'button, input, select, textarea, a, [role="button"]',
+                )
+            )
+                return;
 
             const rect = modal.getBoundingClientRect();
             initialX = rect.left;
@@ -85,12 +98,14 @@
             startX = e.clientX;
             startY = e.clientY;
             isDragging = false;
-            
-            // Set grabbing cursor on mousedown
-            handle.style.cursor = 'grabbing';
 
-            document.addEventListener('mousemove', onMouseMove, { passive: false });
-            document.addEventListener('mouseup', onMouseUp);
+            // Set grabbing cursor on mousedown
+            handle.style.cursor = "grabbing";
+
+            document.addEventListener("mousemove", onMouseMove, {
+                passive: false,
+            });
+            document.addEventListener("mouseup", onMouseUp);
             e.preventDefault();
         }
 
@@ -100,16 +115,24 @@
 
             if (!isDragging && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
                 isDragging = true;
+
                 const rect = modal.getBoundingClientRect();
-                modal.style.width = rect.width + 'px';
-                modal.style.position = 'fixed';
-                modal.style.margin = '0';
-                modal.style.transform = 'none';
-                modal.style.left = rect.left + 'px';
-                modal.style.top = rect.top + 'px';
-                modal.style.right = 'auto';
-                modal.style.bottom = 'auto';
-                modal.classList.add('is-dragging');
+
+                modal.style.width = rect.width + "px";
+                modal.style.height = rect.height + "px";
+                modal.style.position = "fixed";
+                modal.style.margin = "0";
+                modal.style.transform = "none";
+                modal.style.left = rect.left + "px";
+                modal.style.top = rect.top + "px";
+                modal.style.right = "auto";
+                modal.style.bottom = "auto";
+
+                if (isSlideoverModal(modal)) {
+                    modal.classList.add("is-detached");
+                }
+
+                modal.classList.add("is-dragging");
             }
 
             if (!isDragging) return;
@@ -119,26 +142,43 @@
             const rect = modal.getBoundingClientRect();
             const min = 50;
 
-            modal.style.left = Math.max(-rect.width + min, Math.min(initialX + dx, vw - min)) + 'px';
-            modal.style.top = Math.max(10, Math.min(initialY + dy, vh - min)) + 'px';
+            modal.style.left =
+                Math.max(-rect.width + min, Math.min(initialX + dx, vw - min)) +
+                "px";
+            modal.style.top =
+                Math.max(10, Math.min(initialY + dy, vh - min)) + "px";
             e.preventDefault();
         }
 
         function onMouseUp() {
-            if (isDragging) modal.classList.remove('is-dragging');
+            if (isDragging) modal.classList.remove("is-dragging");
             isDragging = false;
-            // Restore move cursor after drag ends
-            handle.style.cursor = 'move';
-            document.removeEventListener('mousemove', onMouseMove);
-            document.removeEventListener('mouseup', onMouseUp);
+            handle.style.cursor = "move";
+            document.removeEventListener("mousemove", onMouseMove);
+            document.removeEventListener("mouseup", onMouseUp);
         }
 
-        handle.addEventListener('mousedown', onMouseDown);
+        handle.addEventListener("mousedown", onMouseDown);
+    }
+
+    function resetSlideoverState() {
+        modal.classList.remove("is-detached");
+        modal.style.width = "";
+        modal.style.height = "";
+        modal.style.position = "";
+        modal.style.margin = "";
+        modal.style.left = "";
+        modal.style.top = "";
+        modal.style.right = "";
+        modal.style.bottom = "";
     }
 
     function scanForModals() {
-        document.querySelectorAll(MODAL_SELECTOR).forEach(modal => {
-            if (!attachedModals.has(modal) && isReallyVisible(modal)) {
+        document.querySelectorAll(MODAL_SELECTOR).forEach((modal) => {
+            if (!attachedModals.has(modal)) {
+                if (modal.classList.contains('hidden') || modal.style.display === 'none') {
+                    return;
+                }
                 makeDraggable(modal);
             }
         });
@@ -146,16 +186,40 @@
 
     function init() {
         scanForModals();
-        setInterval(scanForModals, 500);
+
+        const observer = new MutationObserver((mutations) => {
+            let shouldScan = false;
+            for (const mutation of mutations) {
+                if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
+                    shouldScan = true;
+                    break;
+                }
+                if (mutation.type === "attributes") {
+                    shouldScan = true;
+                    break;
+                }
+            }
+            if (shouldScan) {
+                scanForModals();
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["class", "style"],
+        });
+        setInterval(scanForModals, 1000);
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
     } else {
         init();
     }
 
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
         window.FilamentDraggableModal = { makeDraggable, init };
     }
 })();

--- a/resources/dist/drag-modal.js
+++ b/resources/dist/drag-modal.js
@@ -1,69 +1,96 @@
 /**
  * Filament v5 Draggable Modal
+ * features:
+ * - Makes Filament modals draggable by their header or title area.
+ * - Automatically detects and applies to new modals added to the DOM.
+ * - slideover modals are draggable only if enabled via config .
+ * - border constraints to prevent dragging completely off-screen.
  */
 (function () {
     'use strict';
 
-    const modalSelectors = [
-        '.fi-modal-window',
-        '[role="dialog"]',
-    ];
+    const MODAL_SELECTOR = '.fi-modal-window';
+    const SLIDEOVER_CLASS = 'fi-modal-slide-over';
 
-    const headerSelectors = [
+    const HANDLE_SELECTORS = [
         '.fi-modal-header',
         '.fi-modal-heading',
         '[data-slot="title"]',
         'header',
     ];
 
+    const attachedModals = new WeakSet();
+
+    function getConfig() {
+        return window.FilamentDraggableModalConfig || {
+            enableSlideoverDraggable: false
+        };
+    }
+
+    function isSlideoverModal(modal) {
+        if (!modal) return false;
+        const wrapper = modal.closest('.fi-modal');
+        return wrapper && wrapper.classList.contains(SLIDEOVER_CLASS);
+    }
+
+    function isReallyVisible(el) {
+        if (!el || !document.body.contains(el)) return false;
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (parseFloat(style.opacity) < 0.1) return false;
+        const wrapper = el.closest('.fi-modal');
+        if (wrapper) {
+            const ws = window.getComputedStyle(wrapper);
+            if (ws.display === 'none' || ws.visibility === 'hidden') return false;
+            if (parseFloat(ws.opacity) < 0.1) return false;
+        }
+        return true;
+    }
+
     function makeDraggable(modal) {
-        if (!modal || modal.dataset.draggableModalAttached === '1') return;
+        if (!modal || attachedModals.has(modal)) return;
 
-        const dialogWindow = modal.classList.contains('fi-modal-window')
-            ? modal
-            : (modal.querySelector('.fi-modal-window') || modal);
-
-        if (!dialogWindow) return;
-        modal.dataset.draggableModalAttached = '1';
-
-        let handle = null;
-        for (const sel of headerSelectors) {
-            handle = dialogWindow.querySelector(sel);
-            if (handle) break;
+        // Check if this is a slideover modal and if slideover draggable is disabled
+        const config = getConfig();
+        if (isSlideoverModal(modal) && !config.enableSlideoverDraggable) {
+            return; // Skip making slideover modals draggable if disabled
         }
 
-        if (!handle) handle = dialogWindow;
+        attachedModals.add(modal);
 
-        handle.style.cursor = 'move';
+        modal.classList.add('fi-modal-draggable-enabled');
+
+        let handle = null;
+        for (const sel of HANDLE_SELECTORS) {
+            handle = modal.querySelector(sel);
+            if (handle) break;
+        }
+        if (!handle) handle = modal;
+
+        // Set cursor and user-select styling explicitly
         handle.style.userSelect = 'none';
+        handle.style.cursor = 'move';
 
-        let startX = 0, startY = 0, initialX = 0, initialY = 0;
+        let startX, startY, initialX, initialY, isDragging = false;
 
         function onMouseDown(e) {
             if (e.button !== 0) return;
-            if (e.target.closest('button, input, select, textarea, a')) return;
+            if (e.target.closest('button, input, select, textarea, a, [role="button"]')) return;
 
-            const rect = dialogWindow.getBoundingClientRect();
-
+            const rect = modal.getBoundingClientRect();
             initialX = rect.left;
             initialY = rect.top;
-
             startX = e.clientX;
             startY = e.clientY;
+            isDragging = false;
+            
+            // Set grabbing cursor on mousedown
+            handle.style.cursor = 'grabbing';
 
-            dialogWindow.style.width = rect.width + 'px';
-            // dialogWindow.style.height = rect.height + 'px'; // Let height be auto
-            dialogWindow.style.position = 'fixed';
-            dialogWindow.style.margin = '0';
-            dialogWindow.style.transform = 'none';
-            dialogWindow.style.left = initialX + 'px';
-            dialogWindow.style.top = initialY + 'px';
-            dialogWindow.style.right = 'auto';
-            dialogWindow.style.bottom = 'auto';
-
-            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mousemove', onMouseMove, { passive: false });
             document.addEventListener('mouseup', onMouseUp);
-
             e.preventDefault();
         }
 
@@ -71,11 +98,37 @@
             const dx = e.clientX - startX;
             const dy = e.clientY - startY;
 
-            dialogWindow.style.left = (initialX + dx) + 'px';
-            dialogWindow.style.top = (initialY + dy) + 'px';
+            if (!isDragging && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
+                isDragging = true;
+                const rect = modal.getBoundingClientRect();
+                modal.style.width = rect.width + 'px';
+                modal.style.position = 'fixed';
+                modal.style.margin = '0';
+                modal.style.transform = 'none';
+                modal.style.left = rect.left + 'px';
+                modal.style.top = rect.top + 'px';
+                modal.style.right = 'auto';
+                modal.style.bottom = 'auto';
+                modal.classList.add('is-dragging');
+            }
+
+            if (!isDragging) return;
+
+            const vw = window.innerWidth;
+            const vh = window.innerHeight;
+            const rect = modal.getBoundingClientRect();
+            const min = 50;
+
+            modal.style.left = Math.max(-rect.width + min, Math.min(initialX + dx, vw - min)) + 'px';
+            modal.style.top = Math.max(10, Math.min(initialY + dy, vh - min)) + 'px';
+            e.preventDefault();
         }
 
         function onMouseUp() {
+            if (isDragging) modal.classList.remove('is-dragging');
+            isDragging = false;
+            // Restore move cursor after drag ends
+            handle.style.cursor = 'move';
             document.removeEventListener('mousemove', onMouseMove);
             document.removeEventListener('mouseup', onMouseUp);
         }
@@ -83,28 +136,26 @@
         handle.addEventListener('mousedown', onMouseDown);
     }
 
-    const observer = new MutationObserver(mutations => {
-        for (const m of mutations) {
-            for (const node of m.addedNodes) {
-                if (!(node instanceof HTMLElement)) continue;
-                if (modalSelectors.some(s => node.matches(s))) {
-                    setTimeout(() => makeDraggable(node), 100);
-                } else {
-                    const found = node.querySelector(modalSelectors.join(','));
-                    if (found) setTimeout(() => makeDraggable(found), 100);
-                }
+    function scanForModals() {
+        document.querySelectorAll(MODAL_SELECTOR).forEach(modal => {
+            if (!attachedModals.has(modal) && isReallyVisible(modal)) {
+                makeDraggable(modal);
             }
-        }
-    });
+        });
+    }
 
     function init() {
-        document.querySelectorAll(modalSelectors.join(',')).forEach(makeDraggable);
-        observer.observe(document.body, { childList: true, subtree: true });
+        scanForModals();
+        setInterval(scanForModals, 500);
     }
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init);
     } else {
         init();
+    }
+
+    if (typeof window !== 'undefined') {
+        window.FilamentDraggableModal = { makeDraggable, init };
     }
 })();

--- a/resources/views/components/config.blade.php
+++ b/resources/views/components/config.blade.php
@@ -1,0 +1,19 @@
+@php
+
+    use Filament\Facades\Filament;
+
+    $enableSlideoverDraggable = false;
+
+    if (Filament::hasPlugin('draggable-modal')) {
+        $plugin = Filament::getPlugin('draggable-modal');
+        if ($plugin instanceof \Sanzgrapher\DraggableModal\DraggableModalPlugin) {
+            $enableSlideoverDraggable = $plugin->isSlideoverDraggable();
+        }
+    }
+@endphp
+
+<script>
+    window.FilamentDraggableModalConfig = {
+        enableSlideoverDraggable: @js($enableSlideoverDraggable)
+    };
+</script>

--- a/resources/views/components/config.blade.php
+++ b/resources/views/components/config.blade.php
@@ -1,12 +1,13 @@
 @php
 
     use Filament\Facades\Filament;
+    use Sanzgrapher\DraggableModal\DraggableModalPlugin;
 
     $enableSlideoverDraggable = false;
 
     if (Filament::hasPlugin('draggable-modal')) {
         $plugin = Filament::getPlugin('draggable-modal');
-        if ($plugin instanceof \Sanzgrapher\DraggableModal\DraggableModalPlugin) {
+        if ($plugin instanceof DraggableModalPlugin) {
             $enableSlideoverDraggable = $plugin->isSlideoverDraggable();
         }
     }

--- a/src/DraggableModalPlugin.php
+++ b/src/DraggableModalPlugin.php
@@ -7,6 +7,8 @@ use Filament\Panel;
 
 class DraggableModalPlugin implements Plugin
 {
+    protected bool $enableSlideoverDraggable = false;
+
     public function getId(): string
     {
         return 'draggable-modal';
@@ -25,5 +27,16 @@ class DraggableModalPlugin implements Plugin
     public function boot(Panel $panel): void
     {
         //
+    }
+
+    public function slideoverDraggable(bool $condition = true): static
+    {
+        $this->enableSlideoverDraggable = $condition;
+        return $this;
+    }
+
+    public function isSlideoverDraggable(): bool
+    {
+        return $this->enableSlideoverDraggable;
     }
 }

--- a/src/DraggableModalPlugin.php
+++ b/src/DraggableModalPlugin.php
@@ -29,7 +29,7 @@ class DraggableModalPlugin implements Plugin
         //
     }
 
-    public function slideoverDraggable(bool $condition = true): static
+    public function slideoverDraggable(bool $condition = false): static
     {
         $this->enableSlideoverDraggable = $condition;
         return $this;

--- a/src/DraggableModalServiceProvider.php
+++ b/src/DraggableModalServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Sanzgrapher\DraggableModal;
 
+use Filament\Facades\Filament;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
@@ -13,7 +14,7 @@ class DraggableModalServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // No bindings or registrations needed for this plugin, as it only provides assets
+        // 
     }
 
     public function boot(): void
@@ -34,7 +35,7 @@ class DraggableModalServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'filament-draggable-modal');
         FilamentView::registerRenderHook(
             'panels::body.end',
-            fn (): string => Blade::render('<x-filament-draggable-modal::config />')
+            fn (): string => Filament::hasPlugin('draggable-modal') ? Blade::render('<x-filament-draggable-modal::config />') : ''
         );
     }
 }

--- a/src/DraggableModalServiceProvider.php
+++ b/src/DraggableModalServiceProvider.php
@@ -5,20 +5,36 @@ namespace Sanzgrapher\DraggableModal;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
+use Filament\Support\Facades\FilamentView;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 class DraggableModalServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        //
+        // No bindings or registrations needed for this plugin, as it only provides assets
     }
 
     public function boot(): void
+    {
+        $this->registerAssets();
+        $this->registerViews();
+    }
+
+    private function registerAssets(): void
     {
         FilamentAsset::register([
             Js::make('draggable-modal-js', __DIR__ . '/../resources/dist/drag-modal.js'),
             Css::make('draggable-modal-css', __DIR__ . '/../resources/dist/drag-modal.css'),
         ], 'sanzgrapher/draggable-modal');
+    }
+    private function registerViews(): void
+    {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'filament-draggable-modal');
+        FilamentView::registerRenderHook(
+            'panels::body.end',
+            fn (): string => Blade::render('<x-filament-draggable-modal::config />')
+        );
     }
 }


### PR DESCRIPTION
- Updated README to include slideover support details.
- Modified composer.json to support Filament v5.
- Enhanced drag-modal.js to allow slideover modals to be draggable based on configuration.
- Improved drag-modal.css for better styling of draggable modals.
- Added configuration blade view for slideover draggable setting.
- Updated DraggableModalPlugin to manage slideover draggable state.
- Registered assets and views in DraggableModalServiceProvider.