### PR TITLE
Fix draggable modal affecting slide-overs and non-center dialogs

### DIFF
--- a/resources/dist/drag-modal.css
+++ b/resources/dist/drag-modal.css
@@ -6,9 +6,9 @@
   transition: none !important;
 }
 
-.fi-modal-header,
-.fi-modal-heading,
-[data-slot="title"] {
+.is-draggable-modal .fi-modal-header,
+.is-draggable-modal .fi-modal-heading,
+.is-draggable-modal [data-slot="title"] {
   cursor: move !important;
 }
 

--- a/resources/dist/drag-modal.js
+++ b/resources/dist/drag-modal.js
@@ -19,12 +19,22 @@
     function makeDraggable(modal) {
         if (!modal || modal.dataset.draggableModalAttached === '1') return;
 
+        if (
+            modal.closest('.fi-modal-slide-over') ||
+            modal.classList.contains('fi-modal-slide-over')
+        ) {
+            return;
+        }
+
+        if (window.innerWidth < 768) return;
+
         const dialogWindow = modal.classList.contains('fi-modal-window')
             ? modal
             : (modal.querySelector('.fi-modal-window') || modal);
 
         if (!dialogWindow) return;
         modal.dataset.draggableModalAttached = '1';
+        dialogWindow.classList.add('is-draggable-modal');
 
         let handle = null;
         for (const sel of headerSelectors) {


### PR DESCRIPTION
This PR scopes draggable modal behavior to only center modal windows.

### Changes
- Prevents slide-over / side panel modals from being draggable
- Fixes incorrect cursor behavior on non-draggable dialogs
- Adds proper modal-type detection to avoid interfering with Filament UI components

### Why
The previous implementation targeted `[role="dialog"]`, which also includes slide-overs and notification panels in Filament v5.

This caused unintended UX issues where side panels were draggable when they shouldn't be.

<img width="1881" height="867" alt="image" src="https://github.com/user-attachments/assets/dd168d2c-8f48-4326-aa19-59f3aef27675" />
