### PR TITLE
fix: exclude slide-over modals from dragging

### DIFF
--- a/resources/dist/drag-modal.css
+++ b/resources/dist/drag-modal.css
@@ -6,16 +6,10 @@
   transition: none !important;
 }
 
-.fi-modal-header,
-.fi-modal-heading,
-[data-slot="title"] {
+.is-draggable-modal .fi-modal-header,
+.is-draggable-modal .fi-modal-heading,
+.is-draggable-modal [data-slot="title"] {
   cursor: move !important;
-}
-
-.fi-modal-slide-over .fi-modal-header,
-.fi-modal-slide-over .fi-modal-heading,
-.fi-modal-slide-over [data-slot="title"] {
-  cursor: auto !important;
 }
 
 .fi-modal-header button,

--- a/resources/dist/drag-modal.css
+++ b/resources/dist/drag-modal.css
@@ -2,7 +2,7 @@
  * Filament v5 Draggable Modal Styles
  */
 
-.fi-modal-window {
+.fi-modal:not(.fi-modal-slide-over) .fi-modal-window {
   transition: none !important;
 }
 
@@ -10,6 +10,12 @@
 .fi-modal-heading,
 [data-slot="title"] {
   cursor: move !important;
+}
+
+.fi-modal-slide-over .fi-modal-header,
+.fi-modal-slide-over .fi-modal-heading,
+.fi-modal-slide-over [data-slot="title"] {
+  cursor: auto !important;
 }
 
 .fi-modal-header button,

--- a/resources/dist/drag-modal.js
+++ b/resources/dist/drag-modal.js
@@ -28,6 +28,7 @@
 
         if (!dialogWindow) return;
         modal.dataset.draggableModalAttached = '1';
+        dialogWindow.classList.add('is-draggable-modal');
 
         let handle = null;
         for (const sel of headerSelectors) {

--- a/resources/dist/drag-modal.js
+++ b/resources/dist/drag-modal.js
@@ -19,6 +19,9 @@
     function makeDraggable(modal) {
         if (!modal || modal.dataset.draggableModalAttached === '1') return;
 
+        // Slide-overs are anchored to the viewport edge; leave them non-draggable.
+        if (modal.closest('.fi-modal-slide-over')) return;
+
         const dialogWindow = modal.classList.contains('fi-modal-window')
             ? modal
             : (modal.querySelector('.fi-modal-window') || modal);


### PR DESCRIPTION
> **Credit:** @JonBarakMierke got here first with #6 — I opened this without checking for existing PRs, apologies. The `is-draggable-modal` approach below is theirs, and they're credited as co-author on the commit. Happy for this to be closed in favour of #6 if the maintainer prefers; see the notes at the bottom for the two deltas.

## Summary
Slide-over modals are anchored to the viewport edge and stretched to full height — dragging them makes no sense and breaks their layout and slide-in animation. This PR opts them out of the draggable behavior.

Filament marks slide-overs with the `fi-modal-slide-over` class on the modal root, which is what the exclusion keys on.

## Changes
- `drag-modal.js`:
  - `makeDraggable()` returns early when the dialog is inside `.fi-modal-slide-over`, so no drag handler is attached.
  - The window gets an `is-draggable-modal` class at the moment the handler attaches (@JonBarakMierke's idea from #6).
- `drag-modal.css`:
  - `cursor: move` is scoped to `.is-draggable-modal`, so the cursor follows the actual attach decision rather than duplicating the exclusion logic. This matters because the rule is `!important` and was overriding the inline cursor the JS sets, which is why slide-overs showed a move cursor even though nothing was listening.
  - The `transition: none` override is scoped to non-slide-over windows.

### Why the transition change is needed
Filament animates a slide-over with a `translate-x-full` → `translate-x-0` transform on `.fi-modal-window`, relying on `duration-300` plus the CSS default `transition-property: all`. The plugin's blanket `.fi-modal-window { transition: none !important; }` sets `transition-property: none` and kills that, so a slide-over snapped into place with no animation. Scoping it to `.fi-modal:not(.fi-modal-slide-over)` restores the slide-in while keeping transitions off for draggable modals (where they'd cause lag during a drag).

## Deltas vs #6
Both PRs solve the same problem the same way. Two differences, either of which could just as well be applied to #6:
1. This one also scopes the `transition: none` rule, so slide-overs keep their slide-in animation. #6 leaves that rule global.
2. This one omits the `window.innerWidth < 768` check. It's a separate concern (small-screen/touch support) and as written it's evaluated once at attach time, so it doesn't respond to a window resize — a modal's draggability ends up depending on the viewport width at the moment it was scanned. Worth its own PR with a resize listener.

## Test plan
- Open a regular modal → still draggable by its header, move cursor shown.
- Open a slide-over → default cursor, cannot be dragged, and the slide-in animation plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)